### PR TITLE
Update 0001-add-ant-support-makefile-scripts.patch

### DIFF
--- a/patch/ant/0001-add-ant-support-makefile-scripts.patch
+++ b/patch/ant/0001-add-ant-support-makefile-scripts.patch
@@ -72,7 +72,7 @@ index c0bb761..a5e83f5 100644
 +	cp build/rootfs.cpio.gz  		$(SDIMGDIR)/ramdisk.image.gz
 +	mkimage -A arm -T ramdisk -C gzip -d $(SDIMGDIR)/ramdisk.image.gz $(SDIMGDIR)/uramdisk.image.gz
 +	touch 	$(SDIMGDIR)/boot.bif
-+	echo "image : {[bootloader] $(SDIMGDIR)/fsbl.elf  $(SDIMGDIR)/system_top.bit  $(SDIMGDIR)/u-boot.elf}" >  $(SDIMGDIR)/boot.bif
++	echo "img:{[bootloader] $(SDIMGDIR)/fsbl.elf  $(SDIMGDIR)/system_top.bit  $(SDIMGDIR)/u-boot.elf}" >  $(SDIMGDIR)/boot.bif
 +	bash -c "source $(VIVADO_SETTINGS) && bootgen -image $(SDIMGDIR)/boot.bif -o i $(SDIMGDIR)/BOOT.bin"
 +	rm $(SDIMGDIR)/fsbl.elf
 +	rm $(SDIMGDIR)/system_top.bit


### PR DESCRIPTION
boot.bif format correction

If verified, updates required for other devices and versions as well.